### PR TITLE
Deal with optional newline in event

### DIFF
--- a/filter-10-header.conf
+++ b/filter-10-header.conf
@@ -1,7 +1,7 @@
 filter {
 
   grok {
-    match => ["message", "%{TIMESTAMP_ISO8601:oracledate} %{GREEDYDATA:message}"]
+    match => ["message", "%{TIMESTAMP_ISO8601:oracledate}(\n)?%{SPACE}%{GREEDYDATA:message}"]
     tag_on_failure => ["_grokparsefailure", "oracle_header_failed"]
     id => "oracle_header"
     overwrite => "message"


### PR DESCRIPTION
After ingesting a few more events we found out there are different variants on the system:

* single line events that worked just as we have them in the pattern so far
* multline events where the timestamp is the first line and then everything is in the next line, starting at the begin of the line
* mutline events where all but the first line with the timestamp are indented

This new pattern should be able to deal with all of them.